### PR TITLE
mattdrayer/data-module-cleanup: Keep models internal to data layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 *.py[co]
 
 # Packaging files:
-*.egg*
+*.eggs
+
+# Installation artifacts
+src
 
 # Sphinx docs:
 build

--- a/milestones/serializers.py
+++ b/milestones/serializers.py
@@ -2,6 +2,7 @@
 Data layer serialization operations.  Converts querysets to simple
 python containers (mainly arrays and dicts).
 """
+from models import Milestone
 
 def serialize_milestone(milestone):
     return {
@@ -9,3 +10,10 @@ def serialize_milestone(milestone):
         'namespace': milestone.namespace,
         'description': milestone.description
     }
+
+def deserialize_milestone(milestone_dict):
+    return Milestone(
+        id=milestone_dict.get('id'),
+        namespace=milestone_dict.get('namespace'),
+        description=milestone_dict.get('description')
+    )

--- a/milestones/tests/test_receivers.py
+++ b/milestones/tests/test_receivers.py
@@ -78,11 +78,11 @@ class ReceiverTestCase(TestCase):
         self.assertEqual(len(self.signal_log), 2)
         self.assertEqual(self.signal_log[0]['course_key'], self.test_course_key)
         self.assertEqual(self.signal_log[0]['relationship'], 'requires')
-        self.assertEqual(self.signal_log[0]['milestone'].namespace, unicode(self.test_prerequisite_course_key))
+        self.assertEqual(self.signal_log[0]['milestone']['namespace'], unicode(self.test_prerequisite_course_key))
 
         self.assertEqual(self.signal_log[1]['course_key'], self.test_prerequisite_course_key)
         self.assertEqual(self.signal_log[1]['relationship'], 'fulfills')
-        self.assertEqual(self.signal_log[1]['milestone'].namespace, unicode(self.test_prerequisite_course_key))
+        self.assertEqual(self.signal_log[1]['milestone']['namespace'], unicode(self.test_prerequisite_course_key))
 
     def test_on_course_prerequisite_course_removed(self):
 
@@ -130,4 +130,4 @@ class ReceiverTestCase(TestCase):
         # Confirm the workflow events were properly emitted
         self.assertEqual(len(self.signal_log), 1)
         self.assertEqual(self.signal_log[0]['course_key'], self.test_course_key)
-        self.assertEqual(self.signal_log[0]['milestone'].namespace, unicode(self.test_prerequisite_course_key))
+        self.assertEqual(self.signal_log[0]['milestone']['namespace'], unicode(self.test_prerequisite_course_key))


### PR DESCRIPTION
@ziafazal @ormsbee -- moved leaky Django models back into data layer
