### PR TITLE
SOL-1257: Resetting student history for Entrance Exam on instructor dashboard

### DIFF
--- a/milestones/data.py
+++ b/milestones/data.py
@@ -346,7 +346,9 @@ def fetch_courses_milestones(course_keys, relationship=None, user=None):
     # have for the specified course
     relationships = fetch_milestone_relationship_types()
     if relationship == relationships['REQUIRES'] and user and user.get('id', 0) > 0:
-        queryset = queryset.exclude(milestone__usermilestone__user_id=user['id'])
+        queryset = queryset.exclude(
+            milestone__usermilestone__in=internal.UserMilestone.objects.filter(user_id=user['id'], active=True)
+        )
 
     return [serializers.serialize_milestone_with_course(milestone) for milestone in queryset]
 


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 

Kindly Review this PR, it contains changes for [SOL-1257](https://openedx.atlassian.net/browse/SOL-1257).

**Description of [SOL-1257](https://openedx.atlassian.net/browse/SOL-1257):**
When we reset student's entrance exam history by clicking __Delete Student’s Answers and Scores__ button on instructor dashboard it should clear any user milestones for that entrance exam too. Currently it is not deleting user milestones for entrance exam as a result of this student can access courseware even after deletion of student’s answers and scores if user has passed entrance exam before deleting student's entrance exam history.

cc: @mattdrayer 