### PR TITLE
mattdrayer/update-release-tag: Bump to 0.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='edx-milestones',
-    version='0.1.1',
+    version='0.1.2',
     description='Significant events module for Open edX',
     long_description=open('README.md').read(),
     author='edX',


### PR DESCRIPTION
@nedbat -- creating a new release tag for edx-milestones in order to update the reference in edx-platform.  Last tag was created back in June, but the corresponding change was never made.  So we'll do it now and include all of the changes between then and now in the tag.