### PR TITLE
Changing prefix from b to u in migration files to fix type mismatch

### DIFF
--- a/milestones/__init__.py
+++ b/milestones/__init__.py
@@ -3,4 +3,4 @@ Milestones app initialization module
 """
 from __future__ import unicode_literals
 
-__version__ = '0.2.3'
+__version__ = '0.2.4'

--- a/milestones/migrations/0003_coursecontentmilestone_requirements.py
+++ b/milestones/migrations/0003_coursecontentmilestone_requirements.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='coursecontentmilestone',
             name='requirements',
-            field=models.CharField(help_text=b'Stores JSON data required to determine milestone fulfillment', max_length=255, null=True, blank=True),
+            field=models.CharField(help_text=u'Stores JSON data required to determine milestone fulfillment', max_length=255, null=True, blank=True),
         ),
     ]

--- a/milestones/models.py
+++ b/milestones/models.py
@@ -122,7 +122,7 @@ class CourseContentMilestone(TimeStampedModel):
         max_length=255,
         blank=True,
         null=True,
-        help_text="Stores JSON data required to determine milestone fulfillment"
+        help_text=u"Stores JSON data required to determine milestone fulfillment"
     )
     active = models.BooleanField(default=True, db_index=True)
 


### PR DESCRIPTION
	-The 'b' prefix before strings in migration files causes issues in python3
        - this commit replaces 'b' prefix with 'u' in migration files and adds 'u' prefix in relevant places in model.py
        - this should not cause any issues in python 2