### PR TITLE
Updated Python and Django in Travis and Tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,12 @@
 language: python
 
 python:
-  - 2.7
   - 3.5
+  - 3.8
 
 env:
-  - TOXENV=django111
-
-matrix:
-  include:
-  - python: 3.5
-    env: TOXENV=quality
-  - python: 3.5
-    env: TOXENV=django20
-  - python: 3.5
-    env: TOXENV=django21
-  - python: 3.5
-    env: TOXENV=django22
+  - TOXENV=quality
+  - TOXENV=django22
 
 before_install:
   - export DJANGO_SETTINGS_MODULE=settings
@@ -37,6 +27,6 @@ deploy:
   on:
     tags: true
     python: 3.5
-    condition: '$TOXENV = django111'
+    condition: '$TOXENV = django22'
   password:
     secure: oVeS9OrvR5XvJMg86eO004xk9KFh9IbUxWqyWYYFZf1drtrzG2Bm7+F0BgF1hY2l+qyHXinPCCeBmV9CEfav80se1r8K0JFu9MwBHQkvaeBAJV+ItQ2ZumtgNNONoL5VZHIRbEYwl/lbZCWaXpmDLkJSlRVYCECP2bH+RcZkbQM=

--- a/milestones/api.py
+++ b/milestones/api.py
@@ -363,7 +363,7 @@ def user_has_milestone(user, milestone):
     """
     _validate_user(user)
     _validate_milestone_data(milestone)
-    return True if data.fetch_user_milestones(user, milestone) else False
+    return bool(data.fetch_user_milestones(user, milestone))
 
 
 def remove_user_milestone(user, milestone):

--- a/milestones/models.py
+++ b/milestones/models.py
@@ -1,5 +1,4 @@
 # pylint: disable=no-init
-# pylint: disable=old-style-class
 # pylint: disable=too-few-public-methods
 """
 Database ORM models managed by this Django app

--- a/milestones/services.py
+++ b/milestones/services.py
@@ -8,11 +8,12 @@ import types
 from milestones import api as milestones_api
 
 
-class MilestonesService(object):  # pylint: disable=too-few-public-methods
+class MilestonesService:  # pylint: disable=too-few-public-methods
     """
     An xBlock service for xBlocks to talk to the Milestones subsystem.
 
     NOTE: This is a Singleton class. We should only have one instance of it!
+
     """
 
     _instance = None

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 # Core requirements for using this application
 -c constraints.txt
 
-Django>=1.11                          # Web application framework
+Django                                     # Web application framework
 django-model-utils                         # Provides TimeStampedModel abstract base class
 edx-opaque-keys>=0.2.1                     # Create and introspect course and xblock identities
 six                                        # Utilities for supporting Python 2 & 3 in the same codebase

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,11 +4,12 @@
 #
 #    make upgrade
 #
-django-model-utils==3.2.0
-django==1.11.27
-edx-opaque-keys==2.0.1
-pbr==5.4.4                # via stevedore
+django-model-utils==4.0.0  # via -r requirements/base.in
+django==2.2.12            # via -r requirements/base.in, django-model-utils
+edx-opaque-keys==2.0.2    # via -r requirements/base.in
+pbr==5.4.5                # via stevedore
 pymongo==3.10.1           # via edx-opaque-keys
 pytz==2019.3              # via django
-six==1.14.0
-stevedore==1.31.0         # via edx-opaque-keys
+six==1.14.0               # via -r requirements/base.in, edx-opaque-keys, stevedore
+sqlparse==0.3.1           # via django
+stevedore==1.32.0         # via edx-opaque-keys

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,11 +8,5 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# This packages is a backport which can only be installed on Python 2.7
-futures ; python_version == "2.7"
-
-# Constraining this since the newer versions require Python 3
-more-itertools==5.0.0
-
-# Constraining to version that is compatible with django 1.11.
-django-model-utils<4.0
+# pip-tools==5.0.0 requires PIP version 20 but we are still using version 19.x
+pip-tools<5.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,73 +4,69 @@
 #
 #    make upgrade
 #
-argparse==1.4.0
-astroid==1.6.6
-atomicwrites==1.3.0
-attrs==19.3.0
-backports.functools-lru-cache==1.6.1
-caniusepython3==7.2.0
-certifi==2019.11.28
-chardet==3.0.4
-click-log==0.3.2
-click==7.0
-code-annotations==0.3.3
-codecov==2.0.15
-configparser==4.0.2
-contextlib2==0.6.0.post1
-coverage==5.0.3
-distlib==0.3.0
-django-model-utils==3.2.0
-django==1.11.27
-edx-lint==1.4.1
-edx-opaque-keys==2.0.1
-enum34==1.1.6
-filelock==3.0.12
-funcsigs==1.0.2
-futures==3.3.0 ; python_version == "2.7"
-idna==2.8
-importlib-metadata==1.5.0
-isort==4.3.21
-jinja2==2.11.1
-lazy-object-proxy==1.4.3
-markupsafe==1.1.1
-mccabe==0.6.1
-more-itertools==5.0.0
-packaging==20.1
-pathlib2==2.3.5
-pbr==5.4.4
-pip-tools==4.4.0
-pluggy==0.13.1
-py==1.8.1
-pycodestyle==2.5.0
-pydocstyle==3.0.0
-pylint-celery==0.3
-pylint-django==0.11.1
-pylint-plugin-utils==0.6
-pylint==1.9.5
-pymongo==3.10.1
-pyparsing==2.4.6
-pytest-cov==2.8.1
-pytest-django==3.8.0
-pytest==4.6.9
-python-slugify==4.0.0
-pytz==2019.3
-pyyaml==5.3
-requests==2.22.0
-scandir==1.10.0
-singledispatch==3.4.0.3
-six==1.14.0
-snowballstemmer==2.0.0
-stevedore==1.31.0
-text-unidecode==1.3
-toml==0.10.0
-tox-battery==0.5.2
-tox==3.14.3
-urllib3==1.25.8
-virtualenv==16.7.9
-wcwidth==0.1.8
-wrapt==1.11.2
-zipp==1.1.0
+appdirs==1.4.3            # via -r requirements/travis.txt, virtualenv
+argparse==1.4.0           # via -r requirements/quality.txt, caniusepython3
+astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
+attrs==19.3.0             # via -r requirements/quality.txt, pytest
+backports.functools-lru-cache==1.6.1  # via -r requirements/quality.txt, caniusepython3
+caniusepython3==7.2.0     # via -r requirements/quality.txt
+certifi==2020.4.5.1       # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
+click==7.1.1              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, code-annotations, edx-lint, pip-tools
+code-annotations==0.3.3   # via -r requirements/quality.txt
+codecov==2.0.22           # via -r requirements/travis.txt
+coverage==5.1             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
+distlib==0.3.0            # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, virtualenv
+django-model-utils==4.0.0  # via -r requirements/quality.txt
+django==2.2.12            # via -r requirements/quality.txt, code-annotations, django-model-utils
+edx-lint==1.4.1           # via -r requirements/quality.txt
+edx-opaque-keys==2.0.2    # via -r requirements/quality.txt
+filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
+idna==2.9                 # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+importlib-metadata==1.6.0  # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-resources, pluggy, pytest, tox, virtualenv
+importlib-resources==1.4.0  # via -r requirements/travis.txt, virtualenv
+isort==4.3.21             # via -r requirements/quality.txt, pylint
+jinja2==2.11.2            # via -r requirements/quality.txt, code-annotations
+lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
+markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2
+mccabe==0.6.1             # via -r requirements/quality.txt, pylint
+more-itertools==8.2.0     # via -r requirements/quality.txt, pytest
+packaging==20.3           # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, pytest, tox
+pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
+pbr==5.4.5                # via -r requirements/quality.txt, stevedore
+pip-tools==4.5.1          # via -c requirements/constraints.txt, -r requirements/pip-tools.txt
+pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+py==1.8.1                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+pycodestyle==2.5.0        # via -r requirements/quality.txt
+pydocstyle==5.0.2         # via -r requirements/quality.txt
+pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
+pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
+pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
+pylint==2.4.2             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.10.1           # via -r requirements/quality.txt, edx-opaque-keys
+pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
+pytest-cov==2.8.1         # via -r requirements/quality.txt
+pytest-django==3.9.0      # via -r requirements/quality.txt
+pytest==5.4.1             # via -r requirements/quality.txt, pytest-cov, pytest-django
+python-slugify==4.0.0     # via -r requirements/quality.txt, code-annotations
+pytz==2019.3              # via -r requirements/quality.txt, django
+pyyaml==5.3.1             # via -r requirements/quality.txt, code-annotations
+requests==2.23.0          # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, codecov
+six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-lint, edx-opaque-keys, packaging, pathlib2, pip-tools, stevedore, tox, virtualenv
+snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
+sqlparse==0.3.1           # via -r requirements/quality.txt, django
+stevedore==1.32.0         # via -r requirements/quality.txt, code-annotations, edx-opaque-keys
+text-unidecode==1.3       # via -r requirements/quality.txt, python-slugify
+toml==0.10.0              # via -r requirements/travis.txt, tox
+tox-battery==0.5.2        # via -r requirements/travis.txt
+tox==3.14.6               # via -r requirements/travis.txt, tox-battery
+typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
+urllib3==1.25.9           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+virtualenv==20.0.18       # via -r requirements/travis.txt, tox
+wcwidth==0.1.9            # via -r requirements/quality.txt, pytest
+wrapt==1.11.2             # via -r requirements/quality.txt, astroid
+zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,6 @@
 #
 #    make upgrade
 #
-click==7.0                # via pip-tools
-pip-tools==4.4.0
+click==7.1.1              # via pip-tools
+pip-tools==4.5.1          # via -c requirements/constraints.txt, -r requirements/pip-tools.in
 six==1.14.0               # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -5,65 +5,59 @@
 #    make upgrade
 #
 argparse==1.4.0           # via caniusepython3
-astroid==1.6.6            # via pylint, pylint-celery
-atomicwrites==1.3.0
-attrs==19.3.0
-backports.functools-lru-cache==1.6.1  # via astroid, caniusepython3, isort, pylint
-caniusepython3==7.2.0
-certifi==2019.11.28       # via requests
+astroid==2.3.3            # via pylint, pylint-celery
+attrs==19.3.0             # via -r requirements/test.txt, pytest
+backports.functools-lru-cache==1.6.1  # via caniusepython3
+caniusepython3==7.2.0     # via -r requirements/quality.in
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
-click==7.0
-code-annotations==0.3.3
-configparser==4.0.2
-contextlib2==0.6.0.post1
-coverage==5.0.3
+click==7.1.1              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
+code-annotations==0.3.3   # via -r requirements/test.txt
+coverage==5.1             # via -r requirements/test.txt, pytest-cov
 distlib==0.3.0            # via caniusepython3
-django-model-utils==3.2.0
-django==1.11.27
-edx-lint==1.4.1
-edx-opaque-keys==2.0.1
-enum34==1.1.6             # via astroid
-funcsigs==1.0.2
-futures==3.3.0 ; python_version == "2.7"  # via caniusepython3, isort
-idna==2.8                 # via requests
-importlib-metadata==1.5.0
-isort==4.3.21
-jinja2==2.11.1
+django-model-utils==4.0.0  # via -r requirements/test.txt
+django==2.2.12            # via -r requirements/test.txt, code-annotations, django-model-utils
+edx-lint==1.4.1           # via -r requirements/quality.in
+edx-opaque-keys==2.0.2    # via -r requirements/test.txt
+idna==2.9                 # via requests
+importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
+isort==4.3.21             # via -r requirements/quality.in, pylint
+jinja2==2.11.2            # via -r requirements/test.txt, code-annotations
 lazy-object-proxy==1.4.3  # via astroid
-markupsafe==1.1.1
+markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint
-more-itertools==5.0.0
-packaging==20.1
-pathlib2==2.3.5
-pbr==5.4.4
-pluggy==0.13.1
-py==1.8.1
-pycodestyle==2.5.0
-pydocstyle==3.0.0
+more-itertools==8.2.0     # via -r requirements/test.txt, pytest
+packaging==20.3           # via -r requirements/test.txt, caniusepython3, pytest
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+pbr==5.4.5                # via -r requirements/test.txt, stevedore
+pluggy==0.13.1            # via -r requirements/test.txt, pytest
+py==1.8.1                 # via -r requirements/test.txt, pytest
+pycodestyle==2.5.0        # via -r requirements/quality.in
+pydocstyle==5.0.2         # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
-pylint-django==0.11.1     # via edx-lint
+pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.1
-pyparsing==2.4.6
-pytest-cov==2.8.1
-pytest-django==3.8.0
-pytest==4.6.9
-python-slugify==4.0.0
-pytz==2019.3
-pyyaml==5.3
-requests==2.22.0          # via caniusepython3
-scandir==1.10.0
-singledispatch==3.4.0.3   # via astroid, pylint
-six==1.14.0
+pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
+pyparsing==2.4.7          # via -r requirements/test.txt, packaging
+pytest-cov==2.8.1         # via -r requirements/test.txt
+pytest-django==3.9.0      # via -r requirements/test.txt
+pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
+pytz==2019.3              # via -r requirements/test.txt, django
+pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations
+requests==2.23.0          # via caniusepython3
+six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, edx-opaque-keys, packaging, pathlib2, stevedore
 snowballstemmer==2.0.0    # via pydocstyle
-stevedore==1.31.0
-text-unidecode==1.3
-urllib3==1.25.8           # via requests
-wcwidth==0.1.8
+sqlparse==0.3.1           # via -r requirements/test.txt, django
+stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, edx-opaque-keys
+text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
+typed-ast==1.4.1          # via astroid
+urllib3==1.25.9           # via requests
+wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via astroid
-zipp==1.1.0
+zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,36 +4,32 @@
 #
 #    make upgrade
 #
-atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
-click==7.0                # via code-annotations
-code-annotations==0.3.3
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, zipp
-coverage==5.0.3
-django-model-utils==3.2.0
-edx-opaque-keys==2.0.1
-funcsigs==1.0.2           # via pytest
-importlib-metadata==1.5.0  # via pluggy, pytest
-jinja2==2.11.1            # via code-annotations
+click==7.1.1              # via code-annotations
+code-annotations==0.3.3   # via -r requirements/test.in
+coverage==5.1             # via -r requirements/test.in, pytest-cov
+django-model-utils==4.0.0  # via -r requirements/base.txt
+edx-opaque-keys==2.0.2    # via -r requirements/base.txt
+importlib-metadata==1.6.0  # via pluggy, pytest
+jinja2==2.11.2            # via code-annotations
 markupsafe==1.1.1         # via jinja2
-more-itertools==5.0.0     # via pytest
-packaging==20.1           # via pytest
-pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-django
-pbr==5.4.4
+more-itertools==8.2.0     # via pytest
+packaging==20.3           # via pytest
+pathlib2==2.3.5           # via pytest
+pbr==5.4.5                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
-pymongo==3.10.1
-pyparsing==2.4.6          # via packaging
-pytest-cov==2.8.1
-pytest-django==3.8.0
-pytest==4.6.9
+pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
+pyparsing==2.4.7          # via packaging
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-django==3.9.0      # via -r requirements/test.in
+pytest==5.4.1             # via -r requirements/test.in, pytest-cov, pytest-django
 python-slugify==4.0.0     # via code-annotations
-pytz==2019.3
-pyyaml==5.3               # via code-annotations
-scandir==1.10.0           # via pathlib2
-six==1.14.0
-stevedore==1.31.0
+pytz==2019.3              # via -r requirements/base.txt, django
+pyyaml==5.3.1             # via code-annotations
+six==1.14.0               # via -r requirements/base.txt, edx-opaque-keys, packaging, pathlib2, stevedore
+sqlparse==0.3.1           # via -r requirements/base.txt, django
+stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via python-slugify
-wcwidth==0.1.8            # via pytest
-zipp==1.1.0               # via importlib-metadata
+wcwidth==0.1.9            # via pytest
+zipp==1.2.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,26 +4,25 @@
 #
 #    make upgrade
 #
-certifi==2019.11.28       # via requests
+appdirs==1.4.3            # via virtualenv
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.15
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, zipp
-coverage==5.0.3           # via codecov
-filelock==3.0.12          # via tox
-idna==2.8                 # via requests
-importlib-metadata==1.5.0  # via pluggy, tox
-packaging==20.1           # via tox
-pathlib2==2.3.5           # via importlib-metadata
+codecov==2.0.22           # via -r requirements/travis.in
+coverage==5.1             # via codecov
+distlib==0.3.0            # via virtualenv
+filelock==3.0.12          # via tox, virtualenv
+idna==2.9                 # via requests
+importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.4.0  # via virtualenv
+packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
-pyparsing==2.4.6          # via packaging
-requests==2.22.0          # via codecov
-scandir==1.10.0           # via pathlib2
-six==1.14.0               # via packaging, pathlib2, tox
+pyparsing==2.4.7          # via packaging
+requests==2.23.0          # via codecov
+six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
-tox-battery==0.5.2
-tox==3.14.3
-urllib3==1.25.8           # via requests
-virtualenv==16.7.9        # via tox
-zipp==1.1.0               # via importlib-metadata
+tox-battery==0.5.2        # via -r requirements/travis.in
+tox==3.14.6               # via -r requirements/travis.in, tox-battery
+urllib3==1.25.9           # via requests
+virtualenv==20.0.18       # via tox
+zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35}-django{111},py{35}-django{20,21,22}
+envlist = py{35,38}-django{22,30}
 
 [testenv]
 setenv =
@@ -7,10 +7,8 @@ setenv =
     PYTHONPATH = {toxinidir}
 
 deps =
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
     -r{toxinidir}/requirements/test.txt
 
 commands =


### PR DESCRIPTION
**Issue:** [BOM-1550](https://openedx.atlassian.net/browse/BOM-1550)

### Description
- Removed `python27`, `Django<2.2` from **Travis** and **Tox**.
- Added `Python3.8` and `Django30` in **Tox**.
- Added `Python3.8` in **Travis**.
- Removed not-needed constraints and fixed some quality failures.